### PR TITLE
Fix BUG-001: Local Storage Key Mismatch

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -86,8 +86,8 @@ function clearCompletedTasks() {
 
 // Save tasks to local storage
 function saveTasks() {
-    // BUG 7: Wrong storage key (inconsistent with retrieval)
-    localStorage.setItem('tasks', JSON.stringify(tasks));
+    // Fixed: Using consistent storage key that matches retrieval
+    localStorage.setItem('taskManager', JSON.stringify(tasks));
 }
 
 // Render tasks based on current filter


### PR DESCRIPTION
Fixes #BUG-001

This PR addresses the local storage key mismatch issue that was causing data loss on page refresh. The application was loading tasks using 'taskManager' key but saving them with 'tasks' key.

The fix ensures consistent use of 'taskManager' as the key for both retrieval and storage operations.