### PR TITLE
Fix BUG-009: Replace deprecated keyCode property

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -165,8 +165,8 @@ function filterTasks(filter) {
 addTaskBtn.addEventListener('click', addTask);
 
 taskInput.addEventListener('keypress', function (e) {
-    // BUG 10: Wrong key code check (uses deprecated keyCode property)
-    if (e.keyCode === 13) {
+    // Fixed BUG-009: Replaced deprecated keyCode property with key property
+    if (e.key === 'Enter') {
         addTask();
     }
 });


### PR DESCRIPTION
This PR fixes BUG-009 by replacing the deprecated keyCode property with the recommended key property for keyboard event handling.

Changes:
- Changed 'if (e.keyCode === 13)' to 'if (e.key === Enter)' in app.js
- Updated the comment to indicate the fix

Fixes #BUG-009