### PR TITLE
Fix BUG-006: Task Completion Toggle Not Working

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -65,8 +65,8 @@ function deleteTask(id) {
 function toggleTaskCompletion(id) {
     tasks = tasks.map(task => {
         if (task.id === id) {
-            // BUG 6: Doesn't toggle, only sets to true (can't uncomplete)
-            task.completed = true;
+            // Fixed BUG-006: Now properly toggles between completed and not completed
+            task.completed = !task.completed;
         }
         return task;
     });


### PR DESCRIPTION
This PR fixes BUG-006 where toggling task completion only sets it to true but doesn't allow switching back to incomplete.

Changes:
- Modified 	oggleTaskCompletion() function to properly toggle the completed state
- Now tasks can be marked as both completed and uncompleted

Fixes #BUG-006