### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,69 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual Environment
+venv/
+ENV/
+.env
+
+# IDE files
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+
+# Testing
+.coverage
+htmlcov/
+.pytest_cache/
+nosetests.xml
+coverage.xml
+
+# Local development settings
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Debug files
+debug.log
+
+# Database
+*.sqlite3
+*.db
+
+# Compiled JavaScript
+static/dist/
+
+# Temporary files
+tmp/
+temp/
+
+# Other
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
This PR adds a .gitignore file to the project to exclude common temporary files, log files, and environment-specific files from version control.

The .gitignore file includes patterns for:
- Python bytecode and cache files
- Virtual environment directories
- IDE-specific files
- Log files
- Test coverage reports
- Local development settings
- Temporary files
- Databases
- OS-specific files